### PR TITLE
Disable login without ESI_SECRET_KEY

### DIFF
--- a/lazyblacksmith/templates/base.html
+++ b/lazyblacksmith/templates/base.html
@@ -46,7 +46,7 @@
                             </ul>
                         </li>
                     </ul>
-                    {% else %}
+                    {% elif config.ESI_SECRET_KEY %}
                     <div class="my-0">
                         <a href="{{ url_for('sso.login') }}">
                             <img src="https://web.ccpgamescdn.com/eveonlineassets/developers/eve-sso-login-white-small.png" alt="Log in with eveonline.com" />

--- a/lbtasks/tasks/schedule/task_spawner.py
+++ b/lbtasks/tasks/schedule/task_spawner.py
@@ -34,6 +34,9 @@ UNIVERSE_TASKS = [
 def spawn_character_tasks():
     """ Task triggered every minutes that scan all tasks done to find
     any character based task to do (based on the cached_until field) """
+    if not celery_app.app.config.get("ESI_SECRET_KEY"):
+        return
+
     now = utcnow()
 
     # checking if API is up. If not, just stop it


### PR DESCRIPTION
It is possible to run lazy blacksmith without ESI credentials. When none
are provided:

 - disable the login button
 - do not register any views that interact with sso or accounts
 - skip any character related celery tasks

If users are already logged in, this will cause them to be logged out.