### PR TITLE
Fix sqlalchemy warning for activity_products__eager

### DIFF
--- a/lazyblacksmith/models/sde/item.py
+++ b/lazyblacksmith/models/sde/item.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 from . import db
-from .activity import Activity
 
 
 class Item(db.Model):
@@ -76,7 +75,8 @@ class Item(db.Model):
     activity_products__eager = db.relationship(
         'ActivityProduct',
         lazy='joined',
-        foreign_keys='ActivityProduct.item_id'
+        foreign_keys='ActivityProduct.item_id',
+        viewonly=True
     )
 
     def icon(self, size):


### PR DESCRIPTION
The following warning is given when running migrations:

```
SAWarning: relationship 'Item.activity_products__eager' will copy column
item.id to column activity_product.item_id, which conflicts with
relationship(s): 'ActivityProduct.blueprint' (copies item.id to
activity_product.item_id), 'Item.activity_products' (copies item.id to
activity_product.item_id). If this is not the intention, consider if
these relationships should be linked with back_populates, or if
viewonly=True should be applied to one or more if they are read-only.
```

I have applied `viewonly` to `activity_products__eager` since it appears
to only be used as a performance enhancement and is read only.