### PR TITLE
Add docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,3 +33,4 @@ config.py
 Dockerfile
 tmp
 node_modules
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ docs/_build/
 target/
 
 # nodeJS stuff
+.nvmrc
 node_modules/
 
 # OSX hidden files
@@ -67,6 +68,7 @@ node_modules/
 config.py
 *.sqlite
 *.sublime-*
+.env
 env3/
 config_docker\.py
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,37 +1,42 @@
-FROM python:3.7-slim as builder
-LABEL maintainer="anakhon@gmail.com"
+FROM node:12-slim as js-builder
 
-ARG NODEJS_SOURCE=https://deb.nodesource.com/setup_12.x
+COPY package.json package-lock.json /lb/
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential gcc libpq-dev libmariadb-dev curl
-RUN curl -sL $NODEJS_SOURCE | bash - && apt-get install -y nodejs
+WORKDIR /lb
 
-RUN python -m venv /venv
-ENV PATH="/venv/bin:$PATH"
-
-COPY requirements .
-RUN pip install --upgrade pip
-RUN pip3 install -U -r global-requirements.txt
-RUN pip3 install -U -r mysql-requirements.txt
-RUN pip3 install -U -r postgresql-requirements.txt
-RUN pip3 install -U uwsgi redis
+RUN npm install
 
 COPY . /lb/
 
-RUN chmod a+x /lb/deploy/*
-
-WORKDIR /lb
-RUN npm install
 RUN npm run dist
-RUN rm -fR /lb/node_modules
+
 RUN mkdir -p /static \
     && cp -fR /lb/lazyblacksmith/static/js  /static \
     && cp -fR /lb/lazyblacksmith/static/css /static \
     && cp -fR /lb/lazyblacksmith/static/img /static
 
 # ------------------------------------
+
+FROM python:3.7-slim as py-builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential gcc libpq-dev libmariadb-dev
+
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+COPY requirements .
+
+RUN pip install --upgrade pip && \
+    pip install -U -r global-requirements.txt && \
+    pip install -U -r mysql-requirements.txt && \
+    pip install -U -r postgresql-requirements.txt && \
+    pip install -U uwsgi redis
+
+# ------------------------------------
+
 FROM python:3.7-slim AS runtime
+LABEL maintainer="anakhon@gmail.com"
 
 ENV PATH="/venv/bin:/lb/deploy:$PATH" \
     SECRET_KEY="YouNeedToChangeThis8946513!!??" \
@@ -54,15 +59,22 @@ ENV PATH="/venv/bin:/lb/deploy:$PATH" \
 EXPOSE 9090
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libpq-dev libmariadb-dev unzip bzip2 wget \
+    && apt-get install -y --no-install-recommends libpq-dev libmariadb-dev \
     && groupadd -g 1001 lb \
     && useradd -M -s /bin/false -u 1001 -g lb -d /lb lb
 
+COPY --chown=lb:lb --from=py-builder /venv /venv
+COPY --chown=lb:lb --from=js-builder /static /static
+COPY --chown=lb:lb . /lb/
+
+RUN chmod a+x /lb/deploy/*
+
 VOLUME [ "/static" ]
 
-COPY --chown=lb:lb --from=builder /venv /venv
-COPY --chown=lb:lb --from=builder /lb /lb
-COPY --chown=lb:lb --from=builder /static /static
+RUN mkdir /sde && \
+    chown lb:lb /sde
+
+VOLUME [ "/sde" ]
 
 USER lb:lb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,109 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:14
+    hostname: postgres
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-lazyblacksmith}
+      POSTGRES_USER: lazyblacksmith
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    networks:
+      - lazyblacksmith
+    restart: always
+
+  redis:
+    image: redis:6
+    command: ["redis-server", "--appendonly", "yes"]
+    hostname: redis
+    volumes:
+      - redis_data:/data
+    networks:
+      - lazyblacksmith
+    logging:
+      driver: none
+    restart: always
+
+  # this container will run db migrations and do the initial load of the SDE
+  # if you want to force an SDE update, you can run
+  # `docker-compose run init-db sde-import`
+  init-db:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    command: init-db
+    env_file: .env
+    environment: &service_environment
+      UWSGI_SOCKET_TYPE: ${UWSGI_SOCKET_TYPE:---http}
+      CELERY_BROKER: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+      DB_URI: postgresql://lazyblacksmith:${POSTGRES_PASSWORD:-lazyblacksmith}@postgres/lazyblacksmith
+      SECRET_KEY: ${SECRET_KEY?SECRET_KEY must be set in your .env file}
+      ESI_SECRET_KEY: ${ESI_SECRET_KEY-}
+      ESI_CLIENT_ID: ${ESI_CLIENT_ID-}
+      ESI_REDIRECT_DOMAIN: ${ESI_REDIRECT_DOMAIN-}
+    volumes:
+      - sde:/sde
+    networks:
+      - lazyblacksmith
+    depends_on:
+      - postgres
+      - redis
+
+  uwsgi:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    hostname: web
+    command: uwsgi
+    env_file: .env
+    environment: *service_environment
+    volumes:
+      - static:/static
+    ports:
+      - "${PORT:-9090}:9090"
+    networks:
+      - lazyblacksmith
+    depends_on:
+      init-db:
+        condition: service_completed_successfully
+    restart: always
+
+  celery:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    hostname: celery
+    command: celery
+    env_file: .env
+    environment: *service_environment
+    networks:
+      - lazyblacksmith
+    depends_on:
+      init-db:
+        condition: service_completed_successfully
+    restart: always
+
+  celery-beat:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    command: celery-beat
+    env_file: .env
+    environment: *service_environment
+    networks:
+      - lazyblacksmith
+    depends_on:
+      init-db:
+        condition: service_completed_successfully
+    restart: always
+
+volumes:
+  db_data:
+  redis_data:
+  static:
+  sde:
+
+networks:
+  lazyblacksmith:


### PR DESCRIPTION
This makes it very easy to start up lazy blacksmith locally or in the
cloud using docker-compose.

You must specify a `SECRET_KEY` in a `.env` file in the same directory
as `docker-compose.yml`. You can also set additional configuration
options in the `.env` file such as `ESI_SECRET_KEY`, `ESI_CLIENT_ID`,
and `ESI_REDIRECT_DOMAIN`.

You can easily start lazy blacksmith with `docker-compose up --build`
and update the SDE with `docker-compose run init-db sde-import`.